### PR TITLE
Added files via upload

### DIFF
--- a/signalr-hub.js
+++ b/signalr-hub.js
@@ -44,10 +44,11 @@ angular.module('SignalR', [])
 		Hub.disconnect = function () {
 			Hub.connection.stop();
 		};
-		Hub.connect = function () {
+		Hub.connect = function (queryParams) {
 			var startOptions = {};
 			if(options.transport) startOptions.transport = options.transport;
 			if(options.jsonp) startOptions.jsonp = options.jsonp;
+            if (queryParams) Hub.connection.qs = queryParams;
 			return Hub.connection.start(startOptions);
 		};
 


### PR DESCRIPTION
Added the ability to update the queryParams values on an existing Hub. I was having a problem when multiple users were using the same browser one after the other. One user would disconnect and the next user would connect which would cause the Hub to be called twice, one for each user. To avoid this i keep track of when the hub is instantiated and if it is I just called the connect method. However, doing this was causing the old queryParams to be used since the queryParams are only set when the Hub is instantiated. To overwrite the queryParams, I allow the developer to pass the queryParams on the connect method. I made the changes to the signalr-hub.js. I will update the min file soon. Any feedback is appreciated.